### PR TITLE
Allow SnowblindStep to run on _rate and _rateints

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,8 +27,7 @@ author = 'Author Name'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx_automodapi.automodapi'
-]
+extensions = ['sphinx_automodapi.automodapi']
 numpydoc_show_class_members = False
 
 # Add any paths that contain templates here, relative to this directory.

--- a/src/snowblind/snowblind.py
+++ b/src/snowblind/snowblind.py
@@ -92,22 +92,23 @@ class SnowblindStep(Step):
             # make a boolean slice for each labelled event
             segmentation_slice = event_labels == label
             # Compute radius from equal-area circle
-            radius = np.ceil(np.sqrt(region.area / np.pi) * self.growth_factor)
+            radius = np.sqrt(region.area / np.pi)
+            dilate_radius = np.ceil(radius * self.growth_factor)
             # Warn if there are very large snowballs or showers detected
             if region.area > 900:
                 y, x = region.centroid
                 if ig is None:
-                    msg = f"Large CR masked with radius={radius} at [{round(y)}, {round(x)}]"
+                    msg = f"Large CR masked with radius={radius:.1f} at [{round(y)}, {round(x)}]"
 
                 else:
-                    msg = f"Large CR masked with radius={radius} at [{ig[0]}, {ig[1]}, {round(y)}, {round(x)}]"
+                    msg = f"Large CR masked with radius={radius:.1f} at [{ig[0]}, {ig[1]}, {round(y)}, {round(x)}]"
 
                 self.log.warning(msg)
 
-            if radius > 0:
-                event_dilated |= skimage.morphology.isotropic_dilation(segmentation_slice, radius=radius)
+            if dilate_radius > 0:
+                event_dilated |= skimage.morphology.isotropic_dilation(segmentation_slice, radius=dilate_radius)
             else:
-                event_dilated |= skimage.morphology.isotropic_erosion(segmentation_slice, radius=radius)
+                event_dilated |= skimage.morphology.isotropic_erosion(segmentation_slice, radius=-dilate_radius)
 
         return event_dilated
 

--- a/src/snowblind/snowblind.py
+++ b/src/snowblind/snowblind.py
@@ -96,7 +96,7 @@ class SnowblindStep(Step):
                     msg = f"Large CR masked with radius={radius} at [{round(y)}, {round(x)}]"
 
                 else:
-                    msg = f"Large CR masked with radius={radius} at [{ig[0]}, {ig[0]}, {round(y)}, {round(x)}]"
+                    msg = f"Large CR masked with radius={radius} at [{ig[0]}, {ig[1]}, {round(y)}, {round(x)}]"
                     
                 self.log.warning(msg)
             event_dilated |= skimage.morphology.isotropic_dilation(segmentation_slice, radius=radius)

--- a/src/snowblind/snowblind.py
+++ b/src/snowblind/snowblind.py
@@ -83,6 +83,10 @@ class SnowblindStep(Step):
         
         event_dilated = np.zeros_like(jump_slice)
         
+        if self.growth_factor == 0:
+            event_dilated |= big_events
+            return event_dilated
+            
         # zero-indexed loop, but labels are 1-indexed
         for label, region in zip(range(1, nlabels + 1), region_properties):
             # make a boolean slice for each labelled event
@@ -99,10 +103,15 @@ class SnowblindStep(Step):
                     msg = f"Large CR masked with radius={radius} at [{ig[0]}, {ig[1]}, {round(y)}, {round(x)}]"
                     
                 self.log.warning(msg)
-            event_dilated |= skimage.morphology.isotropic_dilation(segmentation_slice, radius=radius)
-        
+
+            if radius > 0:
+                event_dilated |= skimage.morphology.isotropic_dilation(segmentation_slice, radius=radius)
+            else:
+                event_dilated |= skimage.morphology.isotropic_erosion(segmentation_slice, radius=radius)
+
+
         return event_dilated
-    
+
     def dilate_large_area_jumps(self, bool_jump):
         """
         Dilate a boolean mask with contiguous large areas by a self.growth_factor

--- a/tests/test_snowblind.py
+++ b/tests/test_snowblind.py
@@ -32,6 +32,20 @@ def test_call():
     assert result.groupdq[0, 2, 21, 20] == JUMP_DET
     assert result.groupdq[0, 3, 22, 20] == JUMP_DET
     assert result.groupdq[0, 4, 22, 20] == GOOD
+
+    # Cube mode, e.g., rateints
+    im = datamodels.CubeModel((6, 40, 40))
+    im.dq[1, 15:26, 15:26] = JUMP_DET
+    im.dq[1, 20, 20] = SATURATED
+    im.dq[1, 5, 5] = JUMP_DET
+
+    result = SnowblindStep.call(im)
+
+    # Verify large area got expanded
+    assert result.dq[1, 14, 14] == JUMP_DET
+
+    # Verify single pixel area did not get expanded
+    assert result.dq[1, 6, 6] == GOOD
     
     # Image mode, e.g., rate products
     im = datamodels.ImageModel((40, 40))

--- a/tests/test_snowblind.py
+++ b/tests/test_snowblind.py
@@ -32,3 +32,17 @@ def test_call():
     assert result.groupdq[0, 2, 21, 20] == JUMP_DET
     assert result.groupdq[0, 3, 22, 20] == JUMP_DET
     assert result.groupdq[0, 4, 22, 20] == GOOD
+    
+    # Image mode, e.g., rate products
+    im = datamodels.ImageModel((40, 40))
+    im.dq[15:26, 15:26] = JUMP_DET
+    im.dq[20, 20] = SATURATED
+    im.dq[5, 5] = JUMP_DET
+
+    result = SnowblindStep.call(im)
+
+    # Verify large area got expanded
+    assert result.dq[14, 14] == JUMP_DET
+
+    # Verify single pixel area did not get expanded
+    assert result.dq[6, 6] == GOOD

--- a/tests/test_snowblind.py
+++ b/tests/test_snowblind.py
@@ -46,8 +46,7 @@ def test_call():
 
     # Verify single pixel area did not get expanded
     assert result.dq[1, 6, 6] == GOOD
-    
-    #------------
+
     # Image mode, e.g., rate products
     im = datamodels.ImageModel((40, 40))
     im.dq[15:26, 15:26] = JUMP_DET
@@ -61,9 +60,7 @@ def test_call():
 
     # Verify single pixel area did not get expanded
     assert result.dq[6, 6] == GOOD
-    
+
     # Set different flag value
     result = SnowblindStep.call(im, new_jump_flag=4096)
     assert result.dq[14, 14] & 4096 == 4096
-    
-    

--- a/tests/test_snowblind.py
+++ b/tests/test_snowblind.py
@@ -47,6 +47,7 @@ def test_call():
     # Verify single pixel area did not get expanded
     assert result.dq[1, 6, 6] == GOOD
     
+    #------------
     # Image mode, e.g., rate products
     im = datamodels.ImageModel((40, 40))
     im.dq[15:26, 15:26] = JUMP_DET
@@ -60,3 +61,9 @@ def test_call():
 
     # Verify single pixel area did not get expanded
     assert result.dq[6, 6] == GOOD
+    
+    # Set different flag value
+    result = SnowblindStep.call(im, new_jump_flag=4096)
+    assert result.dq[14, 14] & 4096 == 4096
+    
+    


### PR DESCRIPTION
Add `SnowblindStep` handling for `ImageModel` and `CubeModel` inputs, e.g., ``rate`` and ``rateints`` products.  The logic for deciding what to do is whether or not the datamodel has a `groupdq` or `dq` attribute.

The update also includes a new parameter

    new_jump_flag = integer(default={JUMP_DET}) # DQ flag to set for dilated jumps

to allow the user to set a custom integer flag on the dilated jumps.

Basic tests also included, based on the original tests for the `RampModel` inputs.