### PR TITLE
Rename RcSelfCalStep to OpenPixelStep

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Algorithms for cleaning JWST data.
  - `SnowblindStep`: mask cosmic ray showers and snowballs
  - `JumpPlusStep`: Propagate JUMP_DET and SATURATED flags in GROUPDQ properly for frame-averaged groups
  - `PersistenceFlagStep`: flag pixels effected by persistence exposure-to-exposure
- - `RcSelfCalStep`: flag new hot pixels, open pixels or RC pixels
+ - `OpenPixelStep`: flag new open pixels, hot pixels, or open adjacent pixels
 
 
 ## Installation
@@ -31,6 +31,7 @@ In Python, we can insert `SnowblindStep` and `JumpPlusStep` after `JumpStep` as 
     steps = {
         "jump": {
             "save_results": True,
+            "flag_large_events": False,
             "post_hooks": [
                 "snowblind.SnowblindStep",
                 "snowblind.JumpPlusStep",

--- a/src/snowblind/__init__.py
+++ b/src/snowblind/__init__.py
@@ -2,7 +2,7 @@ from importlib.metadata import version, PackageNotFoundError
 
 from .snowblind import SnowblindStep
 from .jump_plus import JumpPlusStep
-from .rc_selfcal import RcSelfCalStep
+from .selfcal import OpenPixelStep
 from .persist import PersistenceFlagStep
 
 
@@ -16,7 +16,7 @@ __all__ = [
     '__version__',
     'SnowblindStep',
     'JumpPlusStep',
-    'RcSelfCalStep',
+    'OpenPixelStep',
     'PersistenceFlagStep',
 ]
 
@@ -27,6 +27,6 @@ def _get_steps():
     return [
         ("snowblind.SnowblindStep", 'snowblind', False),
         ("snowblind.JumpPlusStep", 'jump_plus', False),
-        ("snowblind.RcSelfCalStep", 'rc_selfcal', False),
+        ("snowblind.OpenPixelStep", 'open_pixel', False),
         ("snowblind.PersistenceFlagStep", 'persist', False),
     ]

--- a/src/snowblind/selfcal.py
+++ b/src/snowblind/selfcal.py
@@ -2,18 +2,18 @@ from os.path import commonprefix
 import warnings
 
 from astropy.stats import sigma_clipped_stats
-from astropy.io import fits
 import numpy as np
 from jwst import datamodels
 from jwst.stpipe import Step
 
 
-RC = datamodels.dqflags.pixel["RC"]
+OPEN = datamodels.dqflags.pixel["OPEN"]
+ADJ_OPEN = datamodels.dqflags.pixel["ADJ_OPEN"]
 DO_NOT_USE = datamodels.dqflags.pixel["DO_NOT_USE"]
 
 
-class RcSelfCalStep(Step):
-    """Removes cross-shaped and other defects caused by RC-type bad pixels in NIR detectors
+class OpenPixelStep(Step):
+    """Flags cross-shaped and hot pixel defects caused by open pixels in NIR detectors
 
     Input is an assocation (or glob pattern of files) of all images in visit or program ID
     on which ones wishes to do a self-cal.  These are split into separate detector stacks,
@@ -22,7 +22,7 @@ class RcSelfCalStep(Step):
     stage 3 pipelines such as tweakreg, skymatch and outlier detection.
 
     Like outlier_detection, the input and output science images are the same, and only the
-    data quality (DQ) array has new pixels flagged as DO_NOT_USE and RC.
+    data quality (DQ) array has new pixels flagged as DO_NOT_USE and ADJ_OPEN.
 
     This should be run after flatfielding is finished in image2 pipeline.  It is fine to
     insert it anywhere in the level3 pipeline before resample.
@@ -34,7 +34,7 @@ class RcSelfCalStep(Step):
         output_use_index = boolean(default=False)
     """
 
-    class_alias = "rc_selfcal"
+    class_alias = "open_pixel"
 
     def process(self, input_data):
         with datamodels.open(input_data) as images:
@@ -66,7 +66,7 @@ class RcSelfCalStep(Step):
 
             for result in results:
                 if result.meta.instrument.detector == detector:
-                    result.dq |= (mask * (DO_NOT_USE | RC)).astype(np.uint32)
+                    result.dq |= (mask * (DO_NOT_USE | ADJ_OPEN)).astype(np.uint32)
 
         return results
 

--- a/tests/test_selfcal.py
+++ b/tests/test_selfcal.py
@@ -1,16 +1,16 @@
 import numpy as np
 from jwst import datamodels
 
-from snowblind import RcSelfCalStep
+from snowblind import OpenPixelStep
 
 
-RC = datamodels.dqflags.pixel["RC"]
+ADJ_OPEN = datamodels.dqflags.pixel["ADJ_OPEN"]
 DO_NOT_USE = datamodels.dqflags.pixel["DO_NOT_USE"]
 GOOD = datamodels.dqflags.pixel["GOOD"]
 
 
 def test_init():
-    step = RcSelfCalStep(threshold=4.5)
+    step = OpenPixelStep(threshold=4.5)
 
     assert step.threshold == 4.5
 
@@ -41,11 +41,11 @@ def test_call():
         image.data[8, 8] += 3 * stddev
 
     # Run the step and see if they're recovered
-    results = RcSelfCalStep.call(images, threshold=3.0)
+    results = OpenPixelStep.call(images, threshold=3.0)
 
     for result in results:
-        assert result.dq[2, 2] == RC | DO_NOT_USE
-        assert result.dq[3, 5] == RC | DO_NOT_USE
-        assert result.dq[8, 8] == RC | DO_NOT_USE
+        assert result.dq[2, 2] == ADJ_OPEN | DO_NOT_USE
+        assert result.dq[3, 5] == ADJ_OPEN | DO_NOT_USE
+        assert result.dq[8, 8] == ADJ_OPEN | DO_NOT_USE
 
         assert result.dq[5, 5] == GOOD


### PR DESCRIPTION
This step essentially finds adjacent open pixels in the NIRCam long detectors, so rename it.  It flags pixels as ADJ_OPEN and DO_NOT_USE, though fundamentally it may also detect OPEN pixels as well, if they are not already labelled in a reference file.