### PR TITLE
Add keyword to allow flagging of pixels below median

### DIFF
--- a/src/snowblind/rc_selfcal.py
+++ b/src/snowblind/rc_selfcal.py
@@ -31,6 +31,7 @@ class RcSelfCalStep(Step):
         save_mask = boolean(default=False)  # write out per-detector bad-pixel masks
         output_use_model = boolean(default=True)
         output_use_index = boolean(default=False)
+        flag_low_signal_pix = boolean(default=False)
     """
 
     class_alias = "rc_selfcal"
@@ -93,7 +94,10 @@ class RcSelfCalStep(Step):
             warnings.filterwarnings(action="ignore",
                                     message="Input data contains invalid values")
             _, med, std = sigma_clipped_stats(median2d, mask_value=np.nan)
+
         mask = median2d > med + self.threshold * std
-        # mask |= median2d < med - self.threshold * std
+        if self.flag_low_signal_pix:
+            self.log.info(f"Flagging pixels {self.threshold}-sigma below median as well as those above.")
+            mask |= median2d < med - self.threshold * std
 
         return mask, median2d


### PR DESCRIPTION
In experimenting with using rcselfcal to flag bad pixels in NIRCam, I've found that there is a small population of pixels with signals well below the median that it would be helpful to flag.

You already had a commented out line for flagging pixels below the median. This PR just adds a keyword to toggle this line on and off, and sets the default to be False.